### PR TITLE
Hooks baked by an immutable list

### DIFF
--- a/benchmark/Benchmark.re
+++ b/benchmark/Benchmark.re
@@ -26,12 +26,15 @@ module Unit = {
   let component = nativeComponent("B");
 
   let createElement = (~depth as _, ~children, ()) => {
-    component((_: Hooks.empty) =>
-      {
-        make: () => (),
-        configureInstance: (~isFirstRender as _, ()) => (),
-        children: listToElement(children),
-      }
+    component(hooks =>
+      (
+        hooks,
+        {
+          make: () => (),
+          configureInstance: (~isFirstRender as _, ()) => (),
+          children: listToElement(children),
+        },
+      )
     );
   };
 };
@@ -103,7 +106,7 @@ module A = {
         },
         hooks,
       );
-    let _: Hooks.empty =
+    let hooks =
       Hooks.effect(
         OnMount,
         () =>
@@ -114,15 +117,18 @@ module A = {
       );
 
     if (depth < 5) {
-      Brisk.listToElement(
-        List.mapi(
-          (i, c) =>
-            make(c, ~depth=depth + 1, ~index=i + childrenIndexOffset, []),
-          children,
+      (
+        hooks,
+        Brisk.listToElement(
+          List.mapi(
+            (i, c) =>
+              make(c, ~depth=depth + 1, ~index=i + childrenIndexOffset, []),
+            children,
+          ),
         ),
       );
     } else {
-      <Unit depth={depth + 1} />;
+      (hooks, <Unit depth={depth + 1} />);
     };
   }
   and componentA = component("A")

--- a/lib/Brisk_reconciler.rei
+++ b/lib/Brisk_reconciler.rei
@@ -86,7 +86,8 @@ module Make:
         ~useDynamicKey: bool=?,
         string,
         ~key: Key.t=?,
-        Hooks.t('slots, 'nextSlots) => syntheticElement
+        Hooks.t('a, unit, 'b, 'b) =>
+        (Hooks.t(unit, unit, 'a, unit), syntheticElement)
       ) =>
       syntheticElement;
 
@@ -95,7 +96,8 @@ module Make:
         ~useDynamicKey: bool=?,
         string,
         ~key: Key.t=?,
-        Hooks.t('slots, 'nextSlots) => outputTreeElement('slots, 'nextSlots)
+        Hooks.t('a, unit, 'b, 'b) =>
+        (Hooks.t(unit, unit, 'a, unit), outputTreeElement('a, 'b))
       ) =>
       syntheticElement;
 

--- a/lib/Brisk_reconciler_internal.re
+++ b/lib/Brisk_reconciler_internal.re
@@ -47,9 +47,9 @@ module Make = (OutputTree: OutputTree) => {
     | UpdatedNode(OutputTree.node, OutputTree.node);
   type outputNodeContainer = Lazy.t(internalOutputNode);
   type outputNodeGroup = list(outputNodeContainer);
-  type instance('slots, 'nextSlots, 'elementType, 'outputNode) = {
-    slots: Hooks.t('slots, 'nextSlots),
-    component: component('slots, 'nextSlots, 'elementType, 'outputNode),
+  type instance('a, 'b, 'elementType, 'outputNode) = {
+    slots: Hooks.state('a, unit),
+    component: component('a, 'b, 'elementType, 'outputNode),
     element,
     instanceSubForest: instanceForest,
     subElements: 'elementType,
@@ -89,7 +89,9 @@ module Make = (OutputTree: OutputTree) => {
     elementType: elementType('slots, 'nextSlots, 'elementType, 'outputNode),
     handedOffInstance:
       ref(option(instance('slots, 'nextSlots, 'elementType, 'outputNode))),
-    render: Hooks.t('slots, 'nextSlots) => 'elementType,
+    render:
+      Hooks.t('slots, unit, 'nextSlots, 'nextSlots) =>
+      (Hooks.t(unit, unit, 'slots, unit), 'elementType),
   }
   and opaqueInstance =
     | Instance(instance('slots, 'nextSlots, 'elementType, 'outputNode))
@@ -465,8 +467,12 @@ module Make = (OutputTree: OutputTree) => {
     let rec ofElement =
             (Element(component) as element)
             : (opaqueInstance, list(list(unit => unit))) => {
-      let slots = Hooks.create(~onSlotsDidChange=OutputTree.markAsStale);
-      let subElements = component.render(slots);
+      let slots = Hooks.createState();
+      let (slots, subElements) =
+        component.render(
+          Hooks.ofState(slots, ~onStateDidChange=OutputTree.markAsStale),
+        );
+      let slots = Hooks.toState(slots);
       let (instanceSubForest, mountEffects) =
         (
           switch (component.elementType) {
@@ -723,10 +729,25 @@ module Make = (OutputTree: OutputTree) => {
 
         let shouldRerender = stateChanged || nextElement !== instance.element;
 
-        let nextSubElements =
-          shouldRerender
-            ? nextComponent.render(updatedInstanceWithNewElement.slots)
-            : instance.subElements;
+        let (nextSlots, nextSubElements) =
+          if (shouldRerender) {
+            let (nextSlots, nextElement) =
+              nextComponent.render(
+                Hooks.ofState(
+                  updatedInstanceWithNewElement.slots,
+                  ~onStateDidChange=OutputTree.markAsStale,
+                ),
+              );
+            (Hooks.toState(nextSlots), nextElement);
+          } else {
+            (instance.slots, instance.subElements);
+          };
+
+        let updatedInstanceWithNewElement = {
+          ...updatedInstanceWithNewElement,
+          slots: nextSlots,
+        };
+
         let {subElements, instanceSubForest} = updatedInstanceWithNewElement;
         let (
           nearestHostOutputNode,

--- a/lib/Brisk_reconciler_internal.re
+++ b/lib/Brisk_reconciler_internal.re
@@ -607,8 +607,9 @@ module Make = (OutputTree: OutputTree) => {
           Element(nextComponent) as nextElement,
         )
         : opaqueInstanceUpdate => {
-      let nextState = updateContext.shouldExecutePendingUpdates ?
-        Hooks.flushPendingStateUpdates(instance.slots) : instance.slots;
+      let nextState =
+        updateContext.shouldExecutePendingUpdates
+          ? Hooks.flushPendingStateUpdates(instance.slots) : instance.slots;
       let stateChanged = nextState !== instance.slots;
 
       let bailOut = !stateChanged && instance.element === nextElement;

--- a/lib/HeterogenousList.re
+++ b/lib/HeterogenousList.re
@@ -1,6 +1,4 @@
-module type Witness = {
-  type t('a);
-};
+module type Witness = {type t('a);};
 
 module type S = {
   type witness('a);
@@ -30,6 +28,8 @@ module type S = {
   type mapper = {f: 'a. witness('a) => option('a)};
 
   let map: (mapper, t('a, 'b)) => t('a, 'b);
+
+  let compareElementsIdentity: (t('a, unit), t('a, unit)) => bool;
 };
 
 module Make = (Witness: Witness) => {
@@ -97,4 +97,12 @@ module Make = (Witness: Witness) => {
           ...map(mapper, t),
         ];
       };
+  let rec compareElementsIdentity: type a. (t(a, unit), t(a, unit)) => bool =
+    (l1, l2) => {
+      switch (l1, l2) {
+      | ([], []) => true
+      | ([{value}, ...t1], [{value: value2}, ...t2]) =>
+        value === value2 && compareElementsIdentity(t1, t2)
+      };
+    };
 };

--- a/lib/HeterogenousList.re
+++ b/lib/HeterogenousList.re
@@ -1,0 +1,85 @@
+module type Witness = {type t('a);};
+
+module type S = {
+  type witness('a);
+
+  type valueContainer('a) = {
+    value: 'a,
+    toWitness: 'a => witness('a),
+  };
+
+  type t('list, 'last) =
+    | []: t('a, 'a)
+    | ::(valueContainer('a), t('l, 't)): t('a => 'l, 't);
+
+  let append:
+    (t('start, 'mid => 'rest), 'mid, 'mid => witness('mid)) =>
+    t('start, 'rest);
+
+  let dropFirst: t('a => 'b, unit) => (valueContainer('a), t('b, unit));
+
+  type opaqueValue =
+    | Any(witness('a)): opaqueValue;
+
+  let iter: (opaqueValue => unit, t('a, 'b)) => unit;
+
+  let fold: (('acc, opaqueValue) => 'acc, 'acc, t('a, 'b)) => 'acc;
+};
+
+module Make = (Witness: Witness) => {
+  type witness('a) = Witness.t('a);
+
+  type valueContainer('a) = {
+    value: 'a,
+    toWitness: 'a => Witness.t('a),
+  };
+
+  type t('list, 'last) =
+    | []: t('a, 'a)
+    | ::(valueContainer('a), t('l, 't)): t('a => 'l, 't);
+
+  let rec append:
+    type start mid rest.
+      (t(start, mid => rest), mid, mid => Witness.t(mid)) => t(start, rest) =
+    (l, value, toWitness) =>
+      switch (l) {
+      | [] => [{value, toWitness}]
+      | [a, ...q] => [a, ...append(q, value, toWitness)]
+      };
+
+  let dropFirst:
+    type a b. t(a => b, unit) => (valueContainer(a), t(b, unit)) =
+    fun
+    | [a, ...q] => (a, q);
+
+  type opaqueValue =
+    | Any(Witness.t('a)): opaqueValue;
+
+  let rec iter: type a b. (opaqueValue => unit, t(a, b)) => unit =
+    (f, l) =>
+      switch (l) {
+      | [] => ()
+      | [{value, toWitness}, ...t] =>
+        f(Any(toWitness(value)));
+        iter(f, t);
+      };
+
+  let rec fold: type a b acc. ((acc, opaqueValue) => acc, acc, t(a, b)) => acc =
+    (f, acc, l) =>
+      switch (l) {
+      | [] => acc
+      | [{value, toWitness}, ...t] =>
+        fold(f, f(acc, Any(toWitness(value))), t)
+      };
+
+  /*
+  let rec map: type a b. (opaqueValue => unit, t(a, b)) => t(a, b) =
+    (f, l) =>
+      switch (l) {
+      | [] => l
+      | [{value, toWitness}, ...t] =>
+        f(Any(toWitness(value)));
+        [f(Any(toWitness(value))), ...map(f, t)];
+      };
+  */
+};

--- a/lib/HeterogenousList.rei
+++ b/lib/HeterogenousList.rei
@@ -1,0 +1,29 @@
+module type Witness = {type t('a);};
+
+module type S = {
+  type witness('a);
+
+  type valueContainer('a) = {
+    value: 'a,
+    toWitness: 'a => witness('a),
+  };
+
+  type t('list, 'last) =
+    | []: t('a, 'a)
+    | ::(valueContainer('a), t('l, 't)): t('a => 'l, 't);
+
+  let append:
+    (t('start, 'mid => 'rest), 'mid, 'mid => witness('mid)) =>
+    t('start, 'rest);
+
+  let dropFirst: t('a => 'b, unit) => (valueContainer('a), t('b, unit));
+
+  type opaqueValue =
+    | Any(witness('a)): opaqueValue;
+
+  let iter: (opaqueValue => unit, t('a, 'b)) => unit;
+
+  let fold: (('acc, opaqueValue) => 'acc, 'acc, t('a, 'b)) => 'acc;
+};
+
+module Make: (Witness: Witness) => S with type witness('a) = Witness.t('a);

--- a/lib/HeterogenousList.rei
+++ b/lib/HeterogenousList.rei
@@ -28,6 +28,8 @@ module type S = {
   type mapper = {f: 'a. witness('a) => option('a)};
 
   let map: (mapper, t('a, 'b)) => t('a, 'b);
+
+  let compareElementsIdentity: (t('a, unit), t('a, unit)) => bool;
 };
 
 module Make: (Witness: Witness) => S with type witness('a) = Witness.t('a);

--- a/lib/HeterogenousList.rei
+++ b/lib/HeterogenousList.rei
@@ -24,6 +24,10 @@ module type S = {
   let iter: (opaqueValue => unit, t('a, 'b)) => unit;
 
   let fold: (('acc, opaqueValue) => 'acc, 'acc, t('a, 'b)) => 'acc;
+
+  type mapper = {f: 'a. witness('a) => option('a)};
+
+  let map: (mapper, t('a, 'b)) => t('a, 'b);
 };
 
 module Make: (Witness: Witness) => S with type witness('a) = Witness.t('a);

--- a/lib/Hooks.re
+++ b/lib/Hooks.re
@@ -13,15 +13,15 @@ type t('a, 'b, 'c, 'd) = {
   onStateDidChange: unit => unit,
 };
 
-type hooks('a, 'b, 'c, 'd) = t('a, 'b, 'c, 'd);
-
 let createState = () => None;
 
-let toHooks = (remaining, ~onStateDidChange) => {
+let ofState = (remaining, ~onStateDidChange) => {
   remaining,
   processed: HeterogenousList.[],
   onStateDidChange,
 };
+
+let toState = ({processed}) => Some(processed);
 
 let processNext =
     (
@@ -264,7 +264,7 @@ let reducer = Reducer.hook;
 let ref = Ref.hook;
 let effect = Effect.hook;
 
-let pendingEffects = (~lifecycle, {slots}) =>
+let pendingEffects = (~lifecycle, hooks) =>
   HeterogenousList.fold(
     (opaqueValue, acc) =>
       switch (opaqueValue) {
@@ -275,7 +275,7 @@ let pendingEffects = (~lifecycle, {slots}) =>
       | _ => acc
       },
     [],
-    slots,
+    hooks,
   )
   |> List.fold_left(
        (acc, effect) =>
@@ -293,19 +293,18 @@ let pendingEffects = (~lifecycle, {slots}) =>
 let flushPendingStateUpdates = hooks =>
   switch (hooks) {
   | Some(hooks) =>
-    let x =
-      HeterogenousList.map(
-        {
-          f: (type a, hook: hook(a)) => {
-            switch (hook) {
-            | Reducer.Reducer(s) => (Reducer.flush(s): option(a))
-            | State.State(s) => (State.flush(s): option(a))
-            | _ => None
-            };
-          },
+    HeterogenousList.map(
+      {
+        f: (type a, hook: hook(a)) => {
+          switch (hook) {
+          | Reducer.Reducer(s) => (Reducer.flush(s): option(a))
+          | State.State(s) => (State.flush(s): option(a))
+          | _ => None
+          };
         },
-        hooks,
-      );
-    x === hooks;
+      },
+      hooks,
+    )
+    |> HeterogenousList.compareElementsIdentity(hooks) == false
   | None => false
   };

--- a/lib/Hooks.rei
+++ b/lib/Hooks.rei
@@ -6,8 +6,10 @@ let createState: unit => state('a, 'b);
 
 type t('a, 'b, 'c, 'd);
 
-let toHooks:
+let ofState:
   (state('a, 'b), ~onStateDidChange: unit => unit) => t('a, 'b, 'c, 'c);
+
+let toState: t('a, 'b, 'c, 'd) => state('c, 'd);
 
 let processNext:
   (
@@ -82,4 +84,4 @@ let effect:
   t('b, unit, 'c, 'd);
 
 let pendingEffects:
-  (~lifecycle: Effect.lifecycle, t('a, 'b)) => list(unit => unit);
+  (~lifecycle: Effect.lifecycle, state('a, unit)) => list(unit => unit);

--- a/lib/Hooks.rei
+++ b/lib/Hooks.rei
@@ -85,3 +85,4 @@ let effect:
 
 let pendingEffects:
   (~lifecycle: Effect.lifecycle, state('a, unit)) => list(unit => unit);
+let flushPendingStateUpdates: state('a, unit) => state('a, unit);

--- a/lib/Hooks.rei
+++ b/lib/Hooks.rei
@@ -1,14 +1,22 @@
 type hook('a) = ..;
 
-module Slots: Slots.S with type witness('a) = hook('a);
+type state('a, 'b);
 
-type t('a, 'b) = {
-  slots: Slots.t('a, 'b),
-  onSlotsDidChange: unit => unit,
-};
-type empty = t(unit, unit);
+let createState: unit => state('a, 'b);
 
-let create: (~onSlotsDidChange: unit => unit) => t('a, 'b);
+type t('a, 'b, 'c, 'd);
+
+let toHooks:
+  (state('a, 'b), ~onStateDidChange: unit => unit) => t('a, 'b, 'c, 'c);
+
+let processNext:
+  (
+    ~default: 'value,
+    ~merge: 'value => 'value=?,
+    ~toWitness: 'value => hook('value),
+    t('value => 'b, unit, 'c, 'value => 'd)
+  ) =>
+  ('value, t('b, unit, 'c, 'd));
 
 module State: {
   type t('a);
@@ -50,29 +58,28 @@ module Effect: {
 };
 
 let state:
-  ('state, t(State.t('state), Slots.t('slots, 'nextSlots))) =>
-  ('state, 'state => unit, t('slots, 'nextSlots));
+  ('state, t(State.t('state) => 'b, unit, 'c, State.t('state) => 'd)) =>
+  ('state, 'state => unit, t('b, unit, 'c, 'd));
 
 let reducer:
   (
     ~initialState: 'state,
     ('action, 'state) => 'state,
-    t(Reducer.t('state), Slots.t('slots, 'nextSlots))
+    t(Reducer.t('state) => 'b, unit, 'c, Reducer.t('state) => 'd)
   ) =>
-  ('state, 'action => unit, t('slots, 'nextSlots));
+  ('state, 'action => unit, t('b, unit, 'c, 'd));
 
 let ref:
-  ('state, t(Ref.t('state), Slots.t('slots, 'nextSlots))) =>
-  ('state, 'state => unit, t('slots, 'nextSlots));
+  ('state, t(Ref.t('state) => 'b, unit, 'c, Ref.t('state) => 'd)) =>
+  ('state, 'state => unit, t('b, unit, 'c, 'd));
 
 let effect:
   (
     Effect.condition('condition),
     Effect.handler,
-    t(Effect.t('condition), Slots.t('slots, 'nextSlots))
+    t(Effect.t('condition) => 'b, unit, 'c, Effect.t('condition) => 'd)
   ) =>
-  t('slots, 'nextSlots);
+  t('b, unit, 'c, 'd);
 
 let pendingEffects:
   (~lifecycle: Effect.lifecycle, t('a, 'b)) => list(unit => unit);
-let flushPendingStateUpdates: t('a, 'b) => bool;

--- a/test/Components.re
+++ b/test/Components.re
@@ -150,15 +150,16 @@ module StatelessButton = {
         (),
       ) =>
     component(h => (h, <Div />));
-  let createElement = (~initialClickCount=?, ~test=?, ~children as _, ()) =>
-    element(make(~initialClickCount?, ~test?, ()));
 };
 
 let testWrapper = (~wrappedText="default", _children) =>
-  component("TestWrapper", (_: Hooks.empty) =>
-    <StatelessButton
-      initialClickCount={"wrapped:" ++ wrappedText ++ ":wrapped"}
-    />
+  component("TestWrapper", hooks =>
+    (
+      hooks,
+      <StatelessButton
+        initialClickCount={"wrapped:" ++ wrappedText ++ ":wrapped"}
+      />,
+    )
   );
 
 module ButtonWrapper = {
@@ -219,11 +220,31 @@ module ToggleClicks = {
   let createElement = (~rAction, ~children as _, ()) =>
     component(hooks => {
       let (state, dispatch, hooks) =
-        Hooks.reducer(~initialState=false, (Click, state) => !state, hooks);
+        Hooks.reducer(
+          ~initialState=false,
+          (Click, state) => {
+            print_endline("reducer");
+            !state;
+          },
+          hooks,
+        );
+      print_endline(string_of_bool(state));
       let hooks =
         Hooks.effect(
           OnMount,
-          () => Some(RemoteAction.subscribe(~handler=dispatch, rAction)),
+          () => {
+            print_endline("subscribe");
+            Some(
+              RemoteAction.subscribe(
+                ~handler=
+                  a => {
+                    print_endline("action");
+                    dispatch(a);
+                  },
+                rAction,
+              ),
+            );
+          },
           hooks,
         );
       (

--- a/test/Components.re
+++ b/test/Components.re
@@ -220,31 +220,14 @@ module ToggleClicks = {
   let createElement = (~rAction, ~children as _, ()) =>
     component(hooks => {
       let (state, dispatch, hooks) =
-        Hooks.reducer(
-          ~initialState=false,
-          (Click, state) => {
-            print_endline("reducer");
-            !state;
-          },
-          hooks,
-        );
-      print_endline(string_of_bool(state));
+        Hooks.reducer(~initialState=false, (Click, state) => !state, hooks);
       let hooks =
         Hooks.effect(
           OnMount,
-          () => {
-            print_endline("subscribe");
+          () =>
             Some(
-              RemoteAction.subscribe(
-                ~handler=
-                  a => {
-                    print_endline("action");
-                    dispatch(a);
-                  },
-                rAction,
-              ),
-            );
-          },
+              RemoteAction.subscribe(~handler=a => dispatch(a), rAction),
+            ),
           hooks,
         );
       (

--- a/test/Test.re
+++ b/test/Test.re
@@ -181,6 +181,8 @@ let core = [
       let cell1 = text("cell1");
       let cell2 = text("cell2");
 
+      print_endline("aki");
+
       testState
       |> flushPendingUpdates
       |> executeSideEffects

--- a/test/Test.re
+++ b/test/Test.re
@@ -181,8 +181,6 @@ let core = [
       let cell1 = text("cell1");
       let cell2 = text("cell2");
 
-      print_endline("aki");
-
       testState
       |> flushPendingUpdates
       |> executeSideEffects


### PR DESCRIPTION
Fixes #4 

This PR introduces difflist-based hooks. I would like to note that this is an experiment and I am looking forward to your feedback. From the user's perspective this is the difference:
```diff
-    component(slots => {
+    component(hooks => {
-      let _slots: Hooks.empty =
+      let hooks =
        Hooks.effect(
          Always,
          () => {
            onEffect();
            Some(onEffectDispose);
          },
-          slots,
+          hooks,
        );
-      listToElement([]);
+      (hooks, listToElement([]));
    });
```

The biggest change from the reconciler perspective is, obviously, that the hooks are baked by an immutable data structure. Honestly I'm not sure if it's a big step forward. What's good is that we can cleanly implement `getDerivedStateFromProps`. Obviously, immutability might bring some benefits down the line, for example if we decide to discard renders for some reason in the future. What (dis)advantages do you see?

TODO:
- [x] compare error message quality
- [x] ~~Improve naming after POC review~~ Done in #12 