### PR TITLE
[REPRO] Bug - Hooks: OnMount effect does not get disposed in some cases

### DIFF
--- a/lib/Hooks.rei
+++ b/lib/Hooks.rei
@@ -73,5 +73,6 @@ let effect:
   ) =>
   t('slots, 'nextSlots);
 
-let executeEffects: (~lifecycle: Effect.lifecycle, t('a, 'b)) => bool;
+let pendingEffects:
+  (~lifecycle: Effect.lifecycle, t('a, 'b)) => list(unit => unit);
 let flushPendingStateUpdates: t('a, 'b) => bool;

--- a/test/Test.re
+++ b/test/Test.re
@@ -851,21 +851,32 @@ let core = [
       let onEffectDispose = () =>
         effectDisposeCallCount := effectDisposeCallCount^ + 1;
 
-      render(
+      let testState = render(
         Components.(
           <Div>
             <EmptyComponentWithOnMountEffect onEffect onEffectDispose />
           </Div>
         ),
       )
-      |> executeSideEffects
-      |> ignore;
+      |> executeSideEffects;
 
       expectInt(~label="The effect should've been run", 1, effectCallCount^);
 
       expectInt(
         ~label="The dispose should not have been run yet",
         0,
+        effectDisposeCallCount^,
+      );
+
+      testState
+      |> update(Components.(<Div />))
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+        ~label=
+          "The effect dispose callback should have been called since the component was un-mounted.",
+        1,
         effectDisposeCallCount^,
       );
     },


### PR DESCRIPTION
__Issue:__ In some cases, the `OnMount` effect disposal function does not get run. Specifically, if a child is remove from a parent element. Note that it _does_ work correctly for the root-level element.

This was discovered in the Revery example browser - the initial, default example has animations  (and the animations are expensive - we re-render every frame). The expectation though is after navigating away, the CPU should relax, since the animations are off - but the animations were still happening as our 'dispose' logic for the `OnMount` effect wasn't triggered. I minimized it to this addition to the test case.