### PR TITLE
Move `element()` calls inside the reconciler to remove the need for `make`

### DIFF
--- a/lib/Brisk_reconciler.rei
+++ b/lib/Brisk_reconciler.rei
@@ -85,22 +85,19 @@ module Make:
       (
         ~useDynamicKey: bool=?,
         string,
+        ~key: Key.t=?,
         Hooks.t('slots, 'nextSlots) => syntheticElement
       ) =>
-      component('slots, 'nextSlots, syntheticElement, outputNodeGroup);
+      syntheticElement;
 
     let nativeComponent:
       (
         ~useDynamicKey: bool=?,
         string,
+        ~key: Key.t=?,
         Hooks.t('slots, 'nextSlots) => outputTreeElement('slots, 'nextSlots)
       ) =>
-      component(
-        'slots,
-        'nextSlots,
-        outputTreeElement('slots, 'nextSlots),
-        outputNodeContainer,
-      );
+      syntheticElement;
 
     module Slots = Slots;
     module Hooks = Hooks;

--- a/lib/Brisk_reconciler_internal.re
+++ b/lib/Brisk_reconciler_internal.re
@@ -1063,9 +1063,6 @@ module Make = (OutputTree: OutputTree) => {
             nextReactElement,
           );
 
-        print_endline(
-          "here " ++ (List.length(mountEffects) |> string_of_int),
-        );
         let enqueuedEffects =
           InstanceForest.pendingEffects(
             ~lifecycle=Hooks.Effect.Unmount,

--- a/lib/Brisk_reconciler_internal.re
+++ b/lib/Brisk_reconciler_internal.re
@@ -193,7 +193,11 @@ module Make = (OutputTree: OutputTree) => {
         let (nextL, nearestHostOutputNode, enqueuedEffects) =
           List.fold_left(
             ((acc, nearestHostOutputNode, enqueuedEffects), element) => {
-              let {nearestHostOutputNode, instanceForest, enqueuedEffects: nextEffects} =
+              let {
+                nearestHostOutputNode,
+                instanceForest,
+                enqueuedEffects: nextEffects,
+              } =
                 fold(f, element, nearestHostOutputNode);
               (
                 [instanceForest, ...acc],
@@ -1059,7 +1063,9 @@ module Make = (OutputTree: OutputTree) => {
             nextReactElement,
           );
 
-          print_endline("here " ++ (List.length(mountEffects) |> string_of_int));
+        print_endline(
+          "here " ++ (List.length(mountEffects) |> string_of_int),
+        );
         let enqueuedEffects =
           InstanceForest.pendingEffects(
             ~lifecycle=Hooks.Effect.Unmount,
@@ -1446,24 +1452,32 @@ module Make = (OutputTree: OutputTree) => {
   /* Temporary mechanism for keeping identity without the first class module */
   let component = (~useDynamicKey=false, debugName) => {
     let handedOffInstance = ref(None);
-    render => {
-      debugName,
-      elementType: React,
-      key: useDynamicKey ? Key.dynamicKeyMagicNumber : Key.none,
-      handedOffInstance,
-      render,
-    };
+    (~key=?, render) =>
+      element(
+        ~key?,
+        {
+          debugName,
+          elementType: React,
+          key: useDynamicKey ? Key.dynamicKeyMagicNumber : Key.none,
+          handedOffInstance,
+          render,
+        },
+      );
   };
 
   let nativeComponent = (~useDynamicKey=false, debugName) => {
     let handedOffInstance = ref(None);
-    render => {
-      debugName,
-      elementType: Host,
-      key: useDynamicKey ? Key.dynamicKeyMagicNumber : Key.none,
-      handedOffInstance,
-      render,
-    };
+    (~key=?, render) =>
+      element(
+        ~key?,
+        {
+          debugName,
+          elementType: Host,
+          key: useDynamicKey ? Key.dynamicKeyMagicNumber : Key.none,
+          handedOffInstance,
+          render,
+        },
+      );
   };
 
   module Slots = Slots;


### PR DESCRIPTION
@wokalski @bryphe I was investigating a ppx approach to simplify the components signature that I discussed yesterday with @wokalski. And I thought what if we just called `element` from _inside_ the `component` call, to alleviate users from the burden of defining `make` and `createElement`.

So, went down that rabbit hole and it seems to compile + tests work? 😮  I'm surely missing something 😄 Let me know what you think! If this works for real, I'd say it's much better than any ppx we can come up with, just because we remove the need to deal with ppxs in userland.

( ⚠️ btw this would be a breaking change of course ⚠️  )