### PR TITLE
bugfix (by wokalski): Fix memory leak in hooks / dispatch / setState

### DIFF
--- a/lib/Hooks.re
+++ b/lib/Hooks.re
@@ -89,9 +89,11 @@ module State = {
     let (stateContainer, nextHooks) =
       processNext(~default=make(initialState), ~toWitness=wrapAsHook, hooks);
 
+    let onStateDidChange = hooks.onStateDidChange;
+
     let setter = nextState => {
       setState(nextState, stateContainer);
-      hooks.onStateDidChange();
+      onStateDidChange();
     };
 
     (stateContainer.currentValue, setter, nextHooks);
@@ -137,9 +139,11 @@ module Reducer = {
     let (stateContainer, hooks) =
       processNext(~default=make(initialState), ~toWitness=wrapAsHook, hooks);
 
+    let onStateDidChange = hooks.onStateDidChange;
+
     let dispatch = action => {
       enqueueUpdate(prevValue => reducer(action, prevValue), stateContainer);
-      hooks.onStateDidChange();
+      onStateDidChange();
     };
 
     (stateContainer.currentValue, dispatch, hooks);


### PR DESCRIPTION
__Issue:__ Upon debugging with @wokalski , we found there was a memory leak in the Revery Playground (and also seemed to be occurring in the native app w/ animations).  

Spent some time in the memory profiler looking at the allocation timeline to track this down. We saw that there were various arrays and closures being retained, and a common cycle in the hooks/dispatch (the `dispatch` method was retaining a `hooks` object, which was retaining a _different_ `dispatch` which as then retaining a _different_ `hooks`).

![image](https://user-images.githubusercontent.com/13532591/57182149-d155a200-6e50-11e9-8e50-4d75e93a4ff8.png)

__Fix:__ @wokalski proposed the fix in this PR, which breaks that retainer chain by making it so that the `dispatch` closure is no longer dependent on hooks.

I tested this and verified on the playground that the allocation timeline is now clean:
![image](https://user-images.githubusercontent.com/13532591/57182176-314c4880-6e51-11e9-909d-2cb60841369c.png)

And I'm also no longer seeing the memory leak on the native side. Thanks @wokalski for the fix! 💯 
