### PR TITLE
Dependencies: Loosen dune version restriction

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "910802ab609939f022596807e6d62308",
+  "checksum": "844c38b7e836535cea0304d6067b47c3",
   "root": "brisk-reconciler@link-dev:./package.json",
   "node": {
     "ocaml@4.7.1004@d41d8cd9": {
@@ -85,14 +85,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -374,20 +374,20 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d"
       ]
     },
-    "@opam/ppxlib@opam:0.5.0@674193ca": {
-      "id": "@opam/ppxlib@opam:0.5.0@674193ca",
+    "@opam/ppxlib@opam:0.6.0@3500c1bb": {
+      "id": "@opam/ppxlib@opam:0.6.0@3500c1bb",
       "name": "@opam/ppxlib",
-      "version": "opam:0.5.0",
+      "version": "opam:0.6.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/bb/bb278ff6e819e0e4a4d8a005bb2512a4#md5:bb278ff6e819e0e4a4d8a005bb2512a4",
-          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.5.0/ppxlib-0.5.0.tbz#md5:bb278ff6e819e0e4a4d8a005bb2512a4"
+          "archive:https://opam.ocaml.org/cache/md5/e2/e2d129139891c135acc6d52a3fa9f731#md5:e2d129139891c135acc6d52a3fa9f731",
+          "archive:https://github.com/ocaml-ppx/ppxlib/releases/download/0.6.0/ppxlib-0.6.0.tbz#md5:e2d129139891c135acc6d52a3fa9f731"
         ],
         "opam": {
           "name": "ppxlib",
-          "version": "0.5.0",
-          "path": "esy.lock/opam/ppxlib.0.5.0"
+          "version": "0.6.0",
+          "path": "esy.lock/opam/ppxlib.0.6.0"
         }
       },
       "overrides": [],
@@ -454,7 +454,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/variantslib@opam:v0.11.0@141b8c3e",
-        "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
@@ -462,7 +462,7 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/variantslib@opam:v0.11.0@141b8c3e",
-        "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -486,7 +486,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/typerep@opam:v0.11.0@625676b6",
-        "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
@@ -494,7 +494,7 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/typerep@opam:v0.11.0@625676b6",
-        "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -542,7 +542,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
@@ -551,7 +551,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
@@ -576,7 +576,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
@@ -585,7 +585,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
@@ -610,14 +610,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -640,13 +640,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71"
       ]
     },
@@ -668,14 +668,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -699,14 +699,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/stdio@opam:v0.11.0@3b11cb88",
-        "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/stdio@opam:v0.11.0@3b11cb88",
-        "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
     },
@@ -728,14 +728,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -758,16 +758,16 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
-        "@opam/octavius@opam:1.2.0@70279919",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
+        "@opam/octavius@opam:1.2.1@6ab49b19",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
-        "@opam/octavius@opam:1.2.0@70279919",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
+        "@opam/octavius@opam:1.2.1@6ab49b19",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -790,7 +790,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_variants_conv@opam:v0.11.1@32a56a8b",
         "@opam/ppx_typerep_conv@opam:v0.11.1@07b7be7b",
         "@opam/ppx_sexp_value@opam:v0.11.0@58f87aae",
@@ -814,7 +814,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_variants_conv@opam:v0.11.1@32a56a8b",
         "@opam/ppx_typerep_conv@opam:v0.11.1@07b7be7b",
         "@opam/ppx_sexp_value@opam:v0.11.0@58f87aae",
@@ -854,14 +854,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -884,14 +884,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -914,7 +914,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_compare@opam:v0.11.1@9ddf10ff",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
@@ -923,7 +923,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_compare@opam:v0.11.1@9ddf10ff",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
@@ -948,7 +948,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/fieldslib@opam:v0.11.0@c86ba0e6",
@@ -956,7 +956,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/fieldslib@opam:v0.11.0@c86ba0e6",
         "@opam/base@opam:v0.11.1@6ff71eb3"
@@ -980,7 +980,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
@@ -988,7 +988,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
@@ -1013,7 +1013,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/stdio@opam:v0.11.0@3b11cb88",
-        "@opam/re@opam:1.9.0@7f4a36a5", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/re@opam:1.9.0@7f4a36a5", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_variants_conv@opam:v0.11.1@32a56a8b",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_inline_test@opam:v0.11.0@b987f92a",
@@ -1029,7 +1029,7 @@
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/stdio@opam:v0.11.0@3b11cb88",
-        "@opam/re@opam:1.9.0@7f4a36a5", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "@opam/re@opam:1.9.0@7f4a36a5", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_variants_conv@opam:v0.11.1@32a56a8b",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_inline_test@opam:v0.11.0@b987f92a",
@@ -1060,14 +1060,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -1183,7 +1183,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
@@ -1191,7 +1191,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
@@ -1215,14 +1215,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]
@@ -1245,7 +1245,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
@@ -1254,7 +1254,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/bin_prot@opam:v0.11.0@7a071ede",
@@ -1279,14 +1279,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_inline_test@opam:v0.11.0@b987f92a",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_inline_test@opam:v0.11.0@b987f92a",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71"
       ]
@@ -1309,7 +1309,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_js_style@opam:v0.11.0@4112bf88",
         "@opam/ppx_hash@opam:v0.11.1@789e28d0",
@@ -1320,7 +1320,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_js_style@opam:v0.11.0@4112bf88",
         "@opam/ppx_hash@opam:v0.11.1@789e28d0",
@@ -1347,7 +1347,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ppx_compare@opam:v0.11.1@9ddf10ff",
@@ -1357,7 +1357,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ppx_sexp_conv@opam:v0.11.2@6626e527",
         "@opam/ppx_here@opam:v0.11.0@c36c7116",
         "@opam/ppx_compare@opam:v0.11.1@9ddf10ff",
@@ -1421,26 +1421,25 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/sexplib0@opam:v0.11.0@9df6bcd1"
       ]
     },
-    "@opam/octavius@opam:1.2.0@70279919": {
-      "id": "@opam/octavius@opam:1.2.0@70279919",
+    "@opam/octavius@opam:1.2.1@6ab49b19": {
+      "id": "@opam/octavius@opam:1.2.1@6ab49b19",
       "name": "@opam/octavius",
-      "version": "opam:1.2.0",
+      "version": "opam:1.2.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/3e/3e6049c39045354853d9dc3a197133ac#md5:3e6049c39045354853d9dc3a197133ac",
-          "archive:https://github.com/ocaml-doc/octavius/archive/v1.2.0.tar.gz#md5:3e6049c39045354853d9dc3a197133ac"
+          "archive:https://opam.ocaml.org/cache/md5/fe/fe5f2e1ea8eba9f8c618580a34942bf1#md5:fe5f2e1ea8eba9f8c618580a34942bf1",
+          "archive:https://github.com/ocaml-doc/octavius/archive/v1.2.1.tar.gz#md5:fe5f2e1ea8eba9f8c618580a34942bf1"
         ],
         "opam": {
           "name": "octavius",
-          "version": "1.2.0",
-          "path": "esy.lock/opam/octavius.1.2.0"
+          "version": "1.2.1",
+          "path": "esy.lock/opam/octavius.1.2.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.0@f744a0c5",
-        "@opam/jbuilder@opam:transition@58bdfe0a",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/jbuilder@opam:transition@58bdfe0a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
@@ -1775,14 +1774,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/base@opam:v0.11.1@6ff71eb3",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.5.0@674193ca",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/ppxlib@opam:0.6.0@3500c1bb",
         "@opam/ocaml-migrate-parsetree@opam:1.2.0@23e55f71",
         "@opam/base@opam:v0.11.1@6ff71eb3"
       ]

--- a/esy.lock/opam/octavius.1.2.1/opam
+++ b/esy.lock/opam/octavius.1.2.1/opam
@@ -1,6 +1,4 @@
-version: "1.2.0"
 opam-version: "2.0"
-name: "octavius"
 maintainer: "leo@lpw25.net"
 authors: [ "Leo White <leo@lpw25.net>" ]
 homepage: "https://github.com/ocaml-doc/octavius"
@@ -11,8 +9,7 @@ bug-reports: "https://github.com/ocaml-doc/octavius/issues"
 tags: ["doc" "ocamldoc" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0" & < "4.08.0"}
-  "ocamlfind" {build}
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta7"}
 ]
 build: [
@@ -22,6 +19,6 @@ build: [
 synopsis: "Ocamldoc comment syntax parser"
 description: "Octavius is a library to parse the `ocamldoc` comment syntax."
 url {
-  src: "https://github.com/ocaml-doc/octavius/archive/v1.2.0.tar.gz"
-  checksum: "md5=3e6049c39045354853d9dc3a197133ac"
+  src: "https://github.com/ocaml-doc/octavius/archive/v1.2.1.tar.gz"
+  checksum: "md5=fe5f2e1ea8eba9f8c618580a34942bf1"
 }

--- a/esy.lock/opam/ppxlib.0.6.0/opam
+++ b/esy.lock/opam/ppxlib.0.6.0/opam
@@ -37,6 +37,6 @@ A comprehensive toolbox for ppx development. It features:
 """
 url {
   src:
-    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.5.0/ppxlib-0.5.0.tbz"
-  checksum: "md5=bb278ff6e819e0e4a4d8a005bb2512a4"
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.6.0/ppxlib-0.6.0.tbz"
+  checksum: "md5=e2d129139891c135acc6d52a3fa9f731"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@esy-ocaml/reason": ">=3.4.0",
-    "@opam/dune": "^1.9.0",
+    "@opam/dune": "^1.7.3",
     "ocaml": ">=4.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
__Issue:__ Unfortunately `dune` @ 1.8.x/1.9.x introduces build issues with Revery (specifically, one of our lower-most dependencies - `reason-gl-matrix`). So we're stuck on dune 1.7.3

__Fix:__ Loosen the version restriction for dune so that we can use `brisk-reconciler` alongside earlier dune versions.