### PR TITLE
Reduce the amount of type variables for hooks

### DIFF
--- a/lib/Brisk_reconciler.rei
+++ b/lib/Brisk_reconciler.rei
@@ -144,8 +144,8 @@ module Make:
         ~useDynamicKey: bool=?,
         string,
         ~key: Key.t=?,
-        Hooks.t('a, unit, 'b, 'b) =>
-        (Hooks.t(unit, unit, 'a, unit), syntheticElement)
+        Hooks.t('a, 'a) =>
+        (Hooks.t(Hooks.nil, 'a), syntheticElement)
       ) =>
       syntheticElement;
 
@@ -157,8 +157,8 @@ module Make:
         ~useDynamicKey: bool=?,
         string,
         ~key: Key.t=?,
-        Hooks.t('a, unit, 'b, 'b) =>
-        (Hooks.t(unit, unit, 'a, unit), outputTreeElement)
+        Hooks.t('a, 'a) =>
+        (Hooks.t(Hooks.nil, 'a), outputTreeElement)
       ) =>
       syntheticElement;
 

--- a/lib/HeterogenousList.rei
+++ b/lib/HeterogenousList.rei
@@ -8,28 +8,40 @@ module type S = {
     toWitness: 'a => witness('a),
   };
 
-  type t('list, 'last) =
-    | []: t('a, 'a)
-    | ::(valueContainer('a), t('l, 't)): t('a => 'l, 't);
+  type nil =
+    | Nil;
+
+  type t('list) =
+    | []: t(nil)
+    | ::(valueContainer('a), t('l)): t('a => 'l);
+
+  type constructor('a) = pri t('tail) => t('after)
+  constraint 'a = ('tail, 'after);
+
+  type init('value) = constructor(('value, 'value));
+
+  let init: init('value);
 
   let append:
-    (t('start, 'mid => 'rest), 'mid, 'mid => witness('mid)) =>
-    t('start, 'rest);
+    (valueContainer('value), constructor(('value => 'b, 'c))) =>
+    constructor(('b, 'c));
 
-  let dropFirst: t('a => 'b, unit) => (valueContainer('a), t('b, unit));
+  let seal: constructor((nil, 'a)) => t('a);
+
+  let dropFirst: t('a => 'b) => (valueContainer('a), t('b));
 
   type opaqueValue =
     | Any(witness('a)): opaqueValue;
 
-  let iter: (opaqueValue => unit, t('a, 'b)) => unit;
+  let iter: (opaqueValue => unit, t('a)) => unit;
 
-  let fold: (('acc, opaqueValue) => 'acc, 'acc, t('a, 'b)) => 'acc;
+  let fold: (('acc, opaqueValue) => 'acc, 'acc, t('a)) => 'acc;
 
   type mapper = {f: 'a. witness('a) => option('a)};
 
-  let map: (mapper, t('a, 'b)) => t('a, 'b);
+  let map: (mapper, t('a)) => t('a);
 
-  let compareElementsIdentity: (t('a, unit), t('a, unit)) => bool;
+  let compareElementsIdentity: (t('a), t('a)) => bool;
 };
 
 module Make: (Witness: Witness) => S with type witness('a) = Witness.t('a);

--- a/lib/Hooks.rei
+++ b/lib/Hooks.rei
@@ -1,24 +1,30 @@
 type hook('a) = ..;
 
-type state('a, 'b);
+type state('a);
 
-let createState: unit => state('a, 'b);
+type t('remaining, 'result);
 
-type t('a, 'b, 'c, 'd);
+type nil;
+type empty;
+type all('a) = t(nil, 'a);
+
+let empty: unit => t('value, 'value);
 
 let ofState:
-  (state('a, 'b), ~onStateDidChange: unit => unit) => t('a, 'b, 'c, 'c);
+  (option(state('b)), ~onStateDidChange: unit => unit) => t('b, 'b);
 
-let toState: t('a, 'b, 'c, 'd) => state('c, 'd);
+let toState: all('a) => state('a);
+
+let printState: option(state('a)) => string;
 
 let processNext:
   (
     ~default: 'value,
     ~merge: 'value => 'value=?,
     ~toWitness: 'value => hook('value),
-    t('value => 'b, unit, 'c, 'value => 'd)
+    t('value => 'c, 'd)
   ) =>
-  ('value, t('b, unit, 'c, 'd));
+  ('value, t('c, 'd));
 
 module State: {
   type t('a);
@@ -60,29 +66,28 @@ module Effect: {
 };
 
 let state:
-  ('state, t(State.t('state) => 'b, unit, 'c, State.t('state) => 'd)) =>
-  ('state, 'state => unit, t('b, unit, 'c, 'd));
+  ('value, t(State.t('value) => 'c, 'd)) =>
+  ('value, 'value => unit, t('c, 'd));
 
 let reducer:
   (
-    ~initialState: 'state,
-    ('action, 'state) => 'state,
-    t(Reducer.t('state) => 'b, unit, 'c, Reducer.t('state) => 'd)
+    ~initialState: 'value,
+    ('b, 'value) => 'value,
+    t(Reducer.t('value) => 'c, 'd)
   ) =>
-  ('state, 'action => unit, t('b, unit, 'c, 'd));
+  ('value, 'b => unit, t('c, 'd));
 
 let ref:
-  ('state, t(Ref.t('state) => 'b, unit, 'c, Ref.t('state) => 'd)) =>
-  ('state, 'state => unit, t('b, unit, 'c, 'd));
+  ('value, t(ref('value) => 'c, 'd)) => ('value, 'value => unit, t('c, 'd));
 
 let effect:
   (
-    Effect.condition('condition),
-    Effect.handler,
-    t(Effect.t('condition) => 'b, unit, 'c, Effect.t('condition) => 'd)
+    Effect.condition('value),
+    unit => option(unit => unit),
+    t(Effect.t('value) => 'c, 'd)
   ) =>
-  t('b, unit, 'c, 'd);
+  t('c, 'd);
 
 let pendingEffects:
-  (~lifecycle: Effect.lifecycle, state('a, unit)) => EffectSequence.t;
-let flushPendingStateUpdates: state('a, unit) => state('a, unit);
+  (~lifecycle: Effect.lifecycle, option(state('a))) => EffectSequence.t;
+let flushPendingStateUpdates: state('a) => state('a);


### PR DESCRIPTION
This PR reduces the size of the hooks type variable. The runtime performance doesn't change (the benchmarks show insignificant differences).

Example:

```reason
let (prevTitle, setTitle, hooks) =
  true ? Hooks.ref(title, hooks) : Hooks.state(title, hooks);
```

The type error on the `Hooks.state` call is:

```
This expression has type (string ref -> 'a, string ref -> 'a) Hooks.t
       but an expression was expected of type
         (string Hooks.State.t -> 'b, 'c) Hooks.t
       Type string ref is not compatible with type string Hooks.State.t 
```

which is quite accurate and understandable.

It used to be:

```
Error: This expression has type
         (string Hooks.Ref.t -> 'a, unit, string Hooks.Ref.t -> 'b,
          string Hooks.Ref.t -> 'b)
         Hooks.t
       but an expression was expected of type
         (string Hooks.State.t -> 'c, unit, 'd, string Hooks.State.t -> 'e)
         Hooks.t
       Type string Hooks.Ref.t is not compatible with type
         string Hooks.State.t
```

Not a huge difference but makes some planned future changes easier.