### PR TITLE
Bug - Hooks: 'OnMount' effect is not disposed when hierarchy is removed

### DIFF
--- a/test/Test.re
+++ b/test/Test.re
@@ -770,6 +770,53 @@ let core = [
     },
   ),
   (
+    "Test 'OnMount' effect in extra-nested component",
+    `Quick,
+    () => {
+      let effectCallCount = ref(0);
+      let effectDisposeCallCount = ref(0);
+      let onEffect = () => effectCallCount := effectCallCount^ + 1;
+      let onEffectDispose = () =>
+        effectDisposeCallCount := effectDisposeCallCount^ + 1;
+
+      /* 
+       * When a parent-of-a-parent of a component with an OnMountEffect is removed,
+       * the OnMount effect doesn't get disposed on removal
+       */
+      let testState =
+        render(
+          Components.(
+            <Div>
+              <Div>
+                <EmptyComponentWithOnMountEffect onEffect onEffectDispose />
+              </Div>
+            </Div>
+          ),
+        )
+        |> executeSideEffects;
+
+      expectInt(~label="The effect should've been run", 1, effectCallCount^);
+
+      expectInt(
+        ~label="The dispose should not have been run yet",
+        0,
+        effectDisposeCallCount^,
+      );
+
+      testState
+      |> update(Components.(<Div />))
+      |> executeSideEffects
+      |> ignore;
+
+      expectInt(
+        ~label=
+          "The effect dispose callback should have been called since the component was un-mounted.",
+        1,
+        effectDisposeCallCount^,
+      );
+    },
+  ),
+  (
     "Test transition from empty list to non-empty list",
     `Quick,
     () => {

--- a/test/Test.re
+++ b/test/Test.re
@@ -775,11 +775,10 @@ let core = [
     () => {
       let effectCallCount = ref(0);
       let effectDisposeCallCount = ref(0);
-      let onEffect = () => effectCallCount := effectCallCount^ + 1;
-      let onEffectDispose = () =>
-        effectDisposeCallCount := effectDisposeCallCount^ + 1;
+      let onEffect = () => incr(effectCallCount);
+      let onEffectDispose = () => incr(effectDisposeCallCount);
 
-      /* 
+      /*
        * When a parent-of-a-parent of a component with an OnMountEffect is removed,
        * the OnMount effect doesn't get disposed on removal
        */


### PR DESCRIPTION
Fixes #41

This adds a test case reproducing the issue - when a parent-of-a-parent is removed, the child OnMount effects are not disposed properly.

This impacted Revery's animations (if you remove an animating element, it uses the OnMount hook disposal to un-register the animation) - it would keep animations alive when transitioning between elements.

Related to #8 