### PR TITLE
Use invalid identifier names for bindings introduced by ppx

### DIFF
--- a/jsx/brisk_jsx.ml
+++ b/jsx/brisk_jsx.ml
@@ -7,13 +7,13 @@ let component_ident ~loc =
   Ast_builder.(pexp_ident ~loc (Located.lident ~loc "brisk-component"))
 
 let component_ident_pattern ~loc =
-  Ast_builder.(ppat_var ~loc AT.{ txt = "brisk-component"; loc })
+  Ast_builder.(ppat_var ~loc (Located.mk ~loc "brisk-component"))
 
 let hooks_ident ~loc =
   Ast_builder.(pexp_ident ~loc (Located.lident ~loc "brisk-hooks"))
 
 let hooks_ident_pattern ~loc =
-  Ast_builder.(ppat_var ~loc AT.{ txt = "brisk-hooks"; loc })
+  Ast_builder.(ppat_var ~loc (Located.mk ~loc "brisk-hooks"))
 
 module JSX_ppx = struct
   let rec props_filter_children ~acc = function

--- a/jsx/brisk_jsx.ml
+++ b/jsx/brisk_jsx.ml
@@ -89,7 +89,7 @@ module Declaration_ppx = struct
       match_ func_pattern loc expr
         ~with_:(fun lbl opt_arg pat child_expression ->
           let make_fun_with_expr ~expr =
-            Ppxlib.Ast_builder.Default.pexp_fun ~loc lbl opt_arg pat expr
+            Ast_builder.pexp_fun ~loc lbl opt_arg pat expr
           in
           let loc = pat.Ppxlib.ppat_loc in
           match (lbl, pat) with
@@ -117,7 +117,7 @@ module Declaration_ppx = struct
       let [%p component_ident_pattern ~loc] =
         [%e create_component_expr]
           ~useDynamicKey:
-            [%e Ppxlib.Ast_builder.Default.(ebool ~loc useDynamicKey)]
+            [%e Ast_builder.(ebool ~loc useDynamicKey)]
           [%e component_name]
       in
       fun ?(key = Brisk_reconciler.Key.none) ->
@@ -197,7 +197,7 @@ module Declaration_ppx = struct
             transform_component_expr ~useDynamicKey ~attribute ~component_name
               expr
           in
-          Ppxlib.Ast_builder.Default.(
+          Ast_builder.(
             value_binding ~pat:component_pat ~loc:value_binding_loc
               ~expr:transformed_expr))
     in

--- a/jsx/brisk_jsx.ml
+++ b/jsx/brisk_jsx.ml
@@ -9,6 +9,12 @@ let component_ident ~loc =
 let component_ident_pattern ~loc =
   Ast_builder.(ppat_var ~loc AT.{ txt = "brisk-component"; loc })
 
+let hooks_ident ~loc =
+  Ast_builder.(pexp_ident ~loc (Located.lident ~loc "brisk-hooks"))
+
+let hooks_ident_pattern ~loc =
+  Ast_builder.(ppat_var ~loc AT.{ txt = "brisk-hooks"; loc })
+
 module JSX_ppx = struct
   let rec props_filter_children ~acc = function
     | [] ->
@@ -260,13 +266,13 @@ module Hooks_ppx = struct
       | Pexp_let (Nonrecursive, [binding], next_expression) ->
           let wrapped_next_expression =
             if contains_hook_expression expr then
-              [%expr [%e next_expression] __brisk_ppx_hooks__]
-            else [%expr [%e next_expression], __brisk_ppx_hooks__]
+              [%expr [%e next_expression] [%e hooks_ident ~loc]]
+            else [%expr [%e next_expression], [%e hooks_ident ~loc]]
           in
           [%expr
-            fun __brisk_ppx_hooks__ ->
-              let [%p binding.pvb_pat], __brisk_ppx_hooks__ =
-                [%e binding.pvb_expr] __brisk_ppx_hooks__
+            fun [%p hooks_ident_pattern ~loc] ->
+              let [%p binding.pvb_pat], [%p hooks_ident_pattern ~loc] =
+                [%e binding.pvb_expr] [%e hooks_ident ~loc]
               in
               [%e wrapped_next_expression]]
       | Pexp_let (Recursive, _, _) ->

--- a/test/Components.re
+++ b/test/Components.re
@@ -233,3 +233,8 @@ module EmptyComponentWithOnMountEffect = {
     empty;
   };
 };
+
+module ShouldAllowComponentProp = {
+  let%component make = (~component, (), hooks) =>
+    (<Div> component </Div>, hooks);
+}


### PR DESCRIPTION
Fixes #49 

This ensures that you cannot accidentally shadow or use "hidden" bindings.