### PR TITLE
Make the ref hook a proper ref

### DIFF
--- a/lib/Hooks.re
+++ b/lib/Hooks.re
@@ -179,9 +179,7 @@ module Ref = {
     let (internalRef, hooks) =
       processNext(~default=ref(initialState), ~toWitness=wrapAsHook, hooks);
 
-    let setter = nextValue => internalRef := nextValue;
-
-    ((internalRef^, setter), hooks);
+    (internalRef, hooks);
   };
 };
 

--- a/lib/Hooks.rei
+++ b/lib/Hooks.rei
@@ -79,7 +79,7 @@ let reducer:
 
 let ref:
   ('value, t(ref('value) => 'c, 'd)) =>
-  (('value, 'value => unit), t('c, 'd));
+  (ref('value), t('c, 'd));
 
 let effect:
   (

--- a/test/Components.re
+++ b/test/Components.re
@@ -54,20 +54,20 @@ module Text = {
     prev: string,
   };
   let%nativeComponent make = (~title="ImABox", ()) => {
-    let%hook (prevTitle, setTitle) = Hooks.ref(title);
+    let%hook (prevTitle) = Hooks.ref(title);
     let%hook () =
       Hooks.effect(
         Always,
         () => {
-          setTitle(title);
+          prevTitle := title;
           None;
         },
       );
     {
       make: () => {name: "Text", element: Text(title)},
       configureInstance: (~isFirstRender, t) => {
-        if (prevTitle != title || isFirstRender) {
-          mountLog := [ChangeText(prevTitle, title), ...mountLog^];
+        if (prevTitle^ != title || isFirstRender) {
+          mountLog := [ChangeText(prevTitle^, title), ...mountLog^];
         };
         t;
       },


### PR DESCRIPTION
This has the `ref` hook return an actual `ref`, removes the setter, and therefore acts, and has to be used, like an ordinary ref that persists across calls.

```reason
let%hook count = Hooks.ref(0);
count := count^ + 1; // Instead of `setCount(count + 1)`
```

The rationale for this change is that the name `ref` implies that the value 1) will be updated immediately, and 2) is a reference that will change its contents when updated elsewhere. Neither of which is true. It therefore acts like a bit of a trap which some people (i.e. me) fall into multiple times despite knowing how it actually works. An example is in https://github.com/revery-ui/revery/pull/648. This change makes both of these implications true, while still fulfilling the role of the current `ref` hook, but at the cost of using a slightly different API than both React and the `state` hook.