### PR TITLE
Only trigger CI on master and PR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,14 @@
 name: $(Build.SourceVersion)
 
+trigger:
+  branches:
+    include:
+    - master
+pr:
+  branches:
+    include:
+    - '*'
+
 stages:
 - stage: Build
   jobs:


### PR DESCRIPTION
This should make it so we don't run CI when pushing to random branches on the repo