### PR TITLE
Fix master for 407 and 406

### DIFF
--- a/lib/Hooks.re
+++ b/lib/Hooks.re
@@ -227,9 +227,9 @@ module Effect = {
           | OnMountAndIf(_, currentConditionValue) => currentConditionValue
           /* The following cases are unreachable because it's
            * Impossible to create a value of type condition(always)
-           * Or condition(onMount) using the If constructor
+           * Or condition(onMount) using the If or OnMountAndIf constructor
            */
-          | Always
+          | Always => previousConditionValue
           | OnMount => previousConditionValue
           };
         if (comparator(previousConditionValue, currentConditionValue)) {


### PR DESCRIPTION
The right fix should be to well type the GADT so we can add refutation case `| _ -> .`